### PR TITLE
Manage primitive arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add aor-embedded-array
 
 ## Usage
 
-In your `App.js` or wherever you want to call `<Admin>` component define the `restClientRouter` like this
+Define the `Create` and `Edit` View like this:
 
 ```jsx
  <EmbeddedArrayInput source="links">
@@ -35,3 +35,23 @@ In your `App.js` or wherever you want to call `<Admin>` component define the `re
  </EmbeddedArrayInput>
 ```
 
+Define the `Show` and `List` View like this:
+
+```jsx
+ <EmbeddedArrayField source="links">
+     <UrlField source="url" />
+     <TextField source="context" />
+     <EmbeddedArrayField source="metadata">
+         <TextField source="name" />
+         <TextField source="value" />
+     </EmbeddedArrayField>
+ </EmbeddedArrayField>
+```
+
+For primitive arrays, define the Views the same way but without the source prop for the unique child:
+
+```jsx
+ <EmbeddedArrayInput source="links">
+     <LongTextInput />
+ </EmbeddedArrayInput>
+```

--- a/src/mui/field/EmbeddedArrayField.js
+++ b/src/mui/field/EmbeddedArrayField.js
@@ -6,7 +6,7 @@ import { SimpleShowLayout } from 'admin-on-rest';
 /**
  * A container component that shows embedded array elements as a list of input sets
  *
- * You must define the fields and pass them as children.
+ * You must define the fields and pass them as children or only use one field for primitive arrays.
  *
  * @example Display all the items of an order
  * // order = {
@@ -20,7 +20,17 @@ import { SimpleShowLayout } from 'admin-on-rest';
  *      <NumberField source="qty" />
  *      <NumberField source="price" options={{ style: 'currency', currency: 'USD' }} />
  * </EmbeddedArrayField>
- *
+ * @example Display all the tags of a product
+ * // product = {
+ * //   id: 123,
+ * //   tags: [
+ * //       'relaxation',
+ * //       'chair',
+ * //   ],
+ * // }
+ * <EmbeddedArrayField source="tags">
+ *      <ChipField />
+ * </EmbeddedArrayField>
  */
 export class EmbeddedArrayField extends Component {
     render() {
@@ -34,7 +44,9 @@ export class EmbeddedArrayField extends Component {
                         <SimpleShowLayout {...layoutProps} key={i}>
                             {React.Children.map(children, child =>
                                 React.cloneElement(child, {
-                                    source: `${source}[${i}].${child.props.source}`,
+                                    source: child.props.source
+                                        ? `${source}[${i}].${child.props.source}`
+                                        : `${source}[${i}]`,
                                 }),
                             )}
                         </SimpleShowLayout>,

--- a/src/mui/field/EmbeddedArrayField.spec.js
+++ b/src/mui/field/EmbeddedArrayField.spec.js
@@ -18,7 +18,7 @@ const record = {
 };
 
 describe('<EmbeddedArrayField />', () => {
-    it('should display 3 nested SimpleShowLayouts', () => {
+    it('should display 2 nested SimpleShowLayouts', () => {
         const wrapper = shallow(
             <EmbeddedArrayField record={record} source="links">
                 <UrlField source="url" />
@@ -28,6 +28,25 @@ describe('<EmbeddedArrayField />', () => {
         assert.equal(2, wrapper.find('SimpleShowLayout').length);
         assert.deepEqual(
             [['links[0].url', 'links[0].context'], ['links[1].url', 'links[1].context']],
+            wrapper.find('SimpleShowLayout').map(s => s.prop('children').map(c => c.props.source)),
+        );
+    });
+});
+
+const primitiveRecord = {
+    links: ['https://www.google.com/', 'https://www.bing.com/'],
+};
+
+describe('<EmbeddedArrayField /> with primitive record', () => {
+    it('should display 2 nested SimpleShowLayouts', () => {
+        const wrapper = shallow(
+            <EmbeddedArrayField record={primitiveRecord} source="links">
+                <UrlField />
+            </EmbeddedArrayField>,
+        );
+        assert.equal(2, wrapper.find('SimpleShowLayout').length);
+        assert.deepEqual(
+            [['links[0]'], ['links[1]']],
             wrapper.find('SimpleShowLayout').map(s => s.prop('children').map(c => c.props.source)),
         );
     });

--- a/src/mui/form/EmbeddedArrayInputFormField.js
+++ b/src/mui/form/EmbeddedArrayInputFormField.js
@@ -11,12 +11,10 @@ import isRequired from './isRequired';
  * with a string you provide
  *
  * @example
- *
  * <EmbeddedArrayInputFormField input={input} prefix={my_prefix} />
- *
  */
 const EmbeddedArrayInputFormField = ({ input, prefix, ...rest }) => {
-    const name = `${prefix}.${input.props.source}`;
+    const name = input.props.source ? `${prefix}.${input.props.source}` : prefix;
     const source = name;
 
     if (input.props.addField) {

--- a/src/mui/input/EmbeddedArrayInput.js
+++ b/src/mui/input/EmbeddedArrayInput.js
@@ -46,8 +46,10 @@ const styles = {
  * An Input component for generating/editing an embedded array
  *
  *
- * Use it with any set of input componentents as children, like `<TextInput>`,
- * `<SelectInput>`, `<RadioButtonGroupInput>` ... etc.
+ * Use it with any set of input components as children, like `<TextInput>`,
+ * `<SelectInput>`, `<RadioButtonGroupInput>`, etc.
+ *
+ * You must define the targeted field for each child or only use one child for primitive arrays.
  *
  * @example
  * export const CommentEdit = (props) => (
@@ -59,6 +61,16 @@ const styles = {
  *                  <ReferenceInput resource="tags" reference="tags" source="tag_id" >
  *                      <SelectInput optionText="name" />
  *                  </ReferenceInput>
+ *               </EmbeddedArrayInput>
+ *         </SimpleForm>
+ *     </Edit>
+ * );
+ * @example
+ * export const CommentEdit = (props) => (
+ *     <Edit {...props}>
+ *         <SimpleForm>
+ *              <EmbeddedArrayInput source="links">
+ *                  <TextInput />
  *               </EmbeddedArrayInput>
  *         </SimpleForm>
  *     </Edit>

--- a/src/mui/input/EmbeddedArrayInput.spec.js
+++ b/src/mui/input/EmbeddedArrayInput.spec.js
@@ -55,3 +55,47 @@ describe('<EmbeddedArrayInput />', () => {
         );
     });
 });
+
+describe('<EmbeddedArrayInput /> with primitive child', () => {
+    const defaultProps = {
+        source: 'sub_items',
+        children: [<TextInput key={1} />],
+        resource: 'the_items',
+        translate: x => x,
+    };
+
+    it('should render FieldArray Element', () => {
+        const wrapper = shallow(<EmbeddedArrayInput {...defaultProps} input={{ value: [{}, {}] }} />);
+        const fieldArrayElement = wrapper.find('FieldArray');
+        assert.equal(fieldArrayElement.prop('name'), 'sub_items');
+    });
+
+    it('should render 4 EmbeddedArrayInputFormField elements', () => {
+        // instantiating an EmbeddedArrayInput to test its renderList function
+        const embeddedArrayInput = new EmbeddedArrayInput(defaultProps);
+
+        // mocking redux-form FieldArray items array
+        const items = ['sub_items[0]', 'sub_items[1]'];
+
+        // shallow rendering the renderList helper to test its contents
+        const renderList = shallow(embeddedArrayInput.renderList({ fields: items }));
+
+        // It should render the container
+        assert.equal(renderList.find('.EmbeddedArrayInputContainer').length, 1);
+
+        // It should render a container for each item
+        assert.equal(renderList.find('.EmbeddedArrayInputItemContainer').length, 2);
+
+        // Totally there should be 2 EmbeddedArrayInputFormField
+        assert.equal(renderList.find('EmbeddedArrayInputFormField').length, 2);
+
+        // It should render 2 items: sub_items[0] and sub_items[1]
+        assert.deepEqual(
+            renderList.find('EmbeddedArrayInputFormField').map(el => {
+                const input = el.prop('input');
+                return [input.type.name, el.prop('prefix')];
+            }),
+            [['TextInput', 'sub_items[0]'], ['TextInput', 'sub_items[1]']],
+        );
+    });
+});


### PR DESCRIPTION
Add the possibility to manage primitive arrays easily.
Simply define a child without a source.
For instance:
```js
product = {
  id: 123,
  tags: [
      'relaxation',
      'chair',
  ],
}
```
```jsx
<EmbeddedArrayInput source="tags">
     <TextInput />
</EmbeddedArrayInput>
```
```jsx
<EmbeddedArrayField source="tags">
     <ChipField />
</EmbeddedArrayField>
```